### PR TITLE
Finally fixed the help message bug

### DIFF
--- a/cogs/utils/menus.py
+++ b/cogs/utils/menus.py
@@ -21,7 +21,7 @@ class HelpMenu(nextcord.ui.Select):
                         value=cog.description if hasattr(cog, "description") else "General miscellaneous commands",
                         inline=False)
 
-        for command in self.mapping[cog]:
+        for command in sorted(self.mapping[cog]):
             embed.add_field(name=command.name, value=command.help.split("\n")[0])
 
         for option in self.options:

--- a/eve.py
+++ b/eve.py
@@ -1,5 +1,3 @@
-# import pdb
-
 import asyncio
 import datetime
 import nextcord
@@ -41,10 +39,8 @@ class Eve():
                 for cog, cmds in copy.items():
                     for c in cmds:
                         try:
-                            # pdb.set_trace()
                             await c.can_run(ctx)
-                        except Exception as e:# commands.CheckFailure:
-                            print(c.name, "cannot be executed because of a", e)
+                        except commands.CheckFailure:
                             mapping[cog].remove(c)
                     if not mapping[cog]:
                         mapping.pop(cog)
@@ -137,7 +133,7 @@ class Eve():
 
         @self.client.command(usage="<extension>", aliases=[])
         @commands.is_owner()
-        async def unload(ctx, extension):  
+        async def unload(ctx, extension):
             """
             Unload an extension for the bot.
             """
@@ -333,7 +329,7 @@ class Eve():
 
         @self.client.command(usage="", aliases=["praxis_lock", "unlock_praxis", "praxis_unlock"])
         @commands.is_owner()
-        async def lock_praxis(ctx):  
+        async def lock_praxis(ctx):
             """
             Toggles the functionality of the fuck_praxis command.
             """

--- a/eve.py
+++ b/eve.py
@@ -1,3 +1,5 @@
+# import pdb
+
 import asyncio
 import datetime
 import nextcord
@@ -33,14 +35,16 @@ class Eve():
             if command is None: # General help
                 mapping = {cog: cog.get_commands() for cog in self.client.cogs.values()}
                 mapping['General'] = [c for c in self.client.walk_commands() if c.cog is None]
-                copy = mapping.copy()
+                copy = {cog: commands[:] for cog, commands in mapping.items()}
 
                 # Only show commands that the invoker can use
                 for cog, cmds in copy.items():
                     for c in cmds:
                         try:
+                            # pdb.set_trace()
                             await c.can_run(ctx)
-                        except commands.CheckFailure:
+                        except Exception as e:# commands.CheckFailure:
+                            print(c.name, "cannot be executed because of a", e)
                             mapping[cog].remove(c)
                     if not mapping[cog]:
                         mapping.pop(cog)
@@ -76,13 +80,20 @@ class Eve():
                     await ctx.send("Apologies, that is not a valid command.")
                     return
 
+                subcmds = cmd.commands
+                for subcommand in cmd.commands:
+                    try:
+                        await cmd.can_run(ctx)
+                    except commands.CheckFailure:
+                        subcmds.remove(subcommand)
+                    
                 embed = nextcord.Embed(title=cmd.name + " info",
                                        description=cmd.help)
                 
                 embed.add_field(name="Aliases",
                                 value=', '.join([self.client.command_prefix[0] + alias for alias in [cmd.name] + sorted(cmd.aliases)]))
                 embed.add_field(name="Usage", value=self.client.command_prefix[0] + cmd.name + " " + cmd.usage)
-                embed.add_field(name="Subcommands", value=', '.join(sorted([command.name for command in cmd.commands])))
+                embed.add_field(name="Subcommands", value=', '.join(sorted([command.name for command in subcmds])))
 
                 await ctx.send(embed=embed)
             else:
@@ -126,7 +137,7 @@ class Eve():
 
         @self.client.command(usage="<extension>", aliases=[])
         @commands.is_owner()
-        async def unload(ctx, extension):
+        async def unload(ctx, extension):  
             """
             Unload an extension for the bot.
             """
@@ -145,14 +156,14 @@ class Eve():
 
 
         @self.client.command(usage="<member> [reason]", aliases=[])
-        @checks.is_admin()
+        @commands.has_permissions(kick_members=True)
         async def kick(ctx, member: nextcord.Member, *, reason=None):
             """
             Kick a server member.
             """
 
         @self.client.command(usage="<member> [reason]", aliases=[])
-        @checks.is_admin()
+        @commands.has_permissions(ban_members=True)
         async def ban(ctx, member: nextcord.Member, *, reason=None):
             """
             Ban a server member.
@@ -162,7 +173,7 @@ class Eve():
         
 
         @self.client.command(usage="<user>", aliases=[])
-        @checks.is_admin()
+        @commands.has_permissions(ban_members=True)
         # Can't do nextcord.Member, because it can't convert a string to a member object
         async def unban(ctx, *, member):
             """
@@ -252,7 +263,7 @@ class Eve():
 
 
         @self.client.command(usage="[number of messages]", aliases=["delete", "del", "remove"])
-        @checks.is_admin()
+        @commands.has_permissions(manage_messages=True)
         async def clear(ctx, amount=10):  # Clears a specified number of lines
             """
             Delete a specified number of messages.
@@ -322,7 +333,7 @@ class Eve():
 
         @self.client.command(usage="", aliases=["praxis_lock", "unlock_praxis", "praxis_unlock"])
         @commands.is_owner()
-        async def lock_praxis(ctx):
+        async def lock_praxis(ctx):  
             """
             Toggles the functionality of the fuck_praxis command.
             """


### PR DESCRIPTION
Users should only be able to see commands that they can use in the help command, and now it works properly.

Also fix some permissions, sort commands in help menu, and hide subcommands that cannot be used by users.